### PR TITLE
rename npm package to karabiner-elements-swapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "karabiner-element-swapper",
+  "name": "karabiner-elements-swapper",
   "version": "1.1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The package is currently published as `karabiner-element-swapper` on npm.
Presumably you wanted to call it `karabiner-elements-swapper` (like your repo name, like in your README and like the Karabiner Elements software :-) ).